### PR TITLE
[PV-9] -> [master]

### DIFF
--- a/parseval/exceptions.py
+++ b/parseval/exceptions.py
@@ -106,3 +106,14 @@ class FloatParsingException(BaseException):
 
     def __repr__(self):
         return f"<FloatParsingException({self.msg})>"
+
+
+class DateTimeParsingException(BaseException):
+    def __init__(self, msg="Column value is not aligned to the provided formats."):
+        self.msg = msg
+
+    def __str__(self):
+        return self.msg
+
+    def __repr__(self):
+        return f"<DateTimeParsingException({self.msg})>"


### PR DESCRIPTION
Built `DateTimeParser`, inherited from `FieldParser`, made following changes:

- Added `format_checking` and `convert` API
- Overridden `not_null`, `max_value` and `min_value` API.
- Default, maximum and minimum values can be provided as string or date time.datetime object. If provided as string, there is a option to provide the format also, by default expected format is `%Y-%m-%d %H:%M:%D`.

Detailed discussion will be provided in documentation.