### PR TITLE
[PV-17] -> [PV-1]

### DIFF
--- a/parseval/example.py
+++ b/parseval/example.py
@@ -46,40 +46,42 @@ if __name__ == "__main__":
         ('C7', ConstantParser('Iron-Man')),
         ('C8', IntegerParser().add_func(parity_check).range(0, 40))
     ]
-    p = Parser(schema=schema)
+    p = Parser(schema=schema, stop_on_error=-1)
 
     """
         Input structure: List of rows
     """
     parsed_data = p.parse([
-        '""|Trig_2020-23-12|A|20200123|2000|21.0934||10',
+        '""|Trig_202-23-12|A|20200123|2000|21.0934||10',
         '"DEF"||abc|||||34',
-        '"DEF"|Manual_2020-23-12||2020-01-23 10:20:23|1200|11||'
+        '"DEF"|Manual2020-23-12||2020-01-23 10:20:23|1200|11||'
     ])
     for line in parsed_data:
         print(line)
-    print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
           " LIST OF LINES ARE PARSED "
-          ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+          ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
 
     """
         Input structure: File object
     """
+    p = Parser(schema=schema, stop_on_error=1)
     with tempfile.NamedTemporaryFile() as tf:
         with open(tf.name, 'w') as sf:
-            sf.writelines('""|Trig_2020-23-12|A|20200123|2000|21.0934||10\n')
+            sf.writelines('""|Trig2020-23-12|A|20200123|2000|21.0934||10\n')
             sf.writelines('"DEF"||abc|||||34\n')
             sf.writelines('"DEF"|Manual_2020-23-12||2020-01-23 10:20:23|1200|11||')
 
         with open(tf.name, 'r') as sf:
             for line in p.parse(sf):
                 print(line)
-    print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+    print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
           " FILE DATA IS PARSED "
-          ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+          ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
     """
     Example with Fixed-width data
     """
+    p = Parser(schema=schema, stop_on_error=0)
     fw_schema = [
         ('C1', FieldParser(1, 2)),
         ('C2', StringParser(3, 5).change_case('U').not_null('nan', allow_white_space=True)),
@@ -96,7 +98,7 @@ if __name__ == "__main__":
     ])
     for line in parsed_data:
         print(line)
-    print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
-          " FIXED-WIDTH IS PARSED "
-          ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+    print("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+          " FIXED-WIDTH LINES ARE PARSED "
+          ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
 


### PR DESCRIPTION
Previously `parser` API used to fail whenever any validation failed. But that should not be enforced. In this commit we have given the flexibility to process only the good rows, also a concept of error thresold is kept, the logic is as follows:
	- when `stop_on_error` value is set to **0**, the process will stop on encountering an validation error,
	- when `stop_on_error` value is set to **-1** or any negative number, the process will skip all erroneous rows and return only valid rows,
	- when `stop_on_error` value is set to any **specific positive number**, the process will allow those many erroneous rows, if erroneous rows exceeds that number, the process will fail.